### PR TITLE
fix: Pass through double dollar signs($$)

### DIFF
--- a/index.js
+++ b/index.js
@@ -43,7 +43,7 @@ function doPreprocess(params) {
     return result[0].line
   }
 
-  let state_eval = options.state ? "$$$self.$capture_state && $$$self.$capture_state()" : "{}"
+  let state_eval = options.state ? "$$self.$capture_state && $$self.$capture_state()" : "{}"
 
   function wrapStatement(statement, filename, line_number) {
     // options.id comes from unit tests only
@@ -51,7 +51,6 @@ function doPreprocess(params) {
     let details = `{statement: ${stringify(statement)}, filename: ${stringify(filename)}, line: ${line_number}, id: "${id}"}`
     let start_ev = `{ let svrp_start = Date.now(); let svrp_exec = Math.random(); let start_state = eval("${state_eval}"); rpDsp('SvelteReactiveStart', ${details}, svrp_start, svrp_exec, start_state);`
     // eval is used to avoid the svelte compiler.
-    // $$$ is used because something is replacing $$ with one $
     let end_ev = `rpDsp('SvelteReactiveEnd', ${details}, svrp_start, svrp_exec, start_state, eval("${state_eval}")); }`
 
     const semicolon = /;$/.test(statement) ? "" : ";"
@@ -101,7 +100,7 @@ function doPreprocess(params) {
 
   function replaceReactiveStatements() {
     replacements.forEach(repl => {
-      code = code.replace(repl.uniqid, repl.statement)
+      code = code.replace(repl.uniqid, () => repl.statement)
     })
   }
 

--- a/tests/unit/input/declared-slots-variable.js
+++ b/tests/unit/input/declared-slots-variable.js
@@ -1,0 +1,2 @@
+let triple;
+$: triple = $$slots.somecontent;

--- a/tests/unit/output/declared-slots-variable.js
+++ b/tests/unit/output/declared-slots-variable.js
@@ -1,0 +1,8 @@
+let triple;
+$: { let svrp_start = Date.now(); let svrp_exec = Math.random(); let start_state = eval("$$self.$capture_state && $$self.$capture_state()"); rpDsp('SvelteReactiveStart', {statement: "triple = $$slots.somecontent;", filename: "", line: 0, id: "ABCD"}, svrp_start, svrp_exec, start_state); triple = $$slots.somecontent; rpDsp('SvelteReactiveEnd', {statement: "triple = $$slots.somecontent;", filename: "", line: 0, id: "ABCD"}, svrp_start, svrp_exec, start_state, eval("$$self.$capture_state && $$self.$capture_state()")); }
+
+ var rpGlobal = typeof window !== "undefined" ? window : global; 
+
+ rpGlobal.rpDsp = rpGlobal.rpDsp || function() {}; 
+
+rpDsp('SvelteReactiveEnable', {version: "0.8.2"});

--- a/tests/unit/output/declared.js
+++ b/tests/unit/output/declared.js
@@ -1,2 +1,8 @@
 let triple;
 $: { let svrp_start = Date.now(); let svrp_exec = Math.random(); let start_state = eval("$$self.$capture_state && $$self.$capture_state()"); rpDsp('SvelteReactiveStart', {statement: "triple = count * 3;", filename: "", line: 0, id: "ABCD"}, svrp_start, svrp_exec, start_state); triple = count * 3; rpDsp('SvelteReactiveEnd', {statement: "triple = count * 3;", filename: "", line: 0, id: "ABCD"}, svrp_start, svrp_exec, start_state, eval("$$self.$capture_state && $$self.$capture_state()")); }
+
+ var rpGlobal = typeof window !== "undefined" ? window : global; 
+
+ rpGlobal.rpDsp = rpGlobal.rpDsp || function() {}; 
+
+rpDsp('SvelteReactiveEnable', {version: "0.8.2"});

--- a/tests/unit/output/exported.js
+++ b/tests/unit/output/exported.js
@@ -1,2 +1,8 @@
 export let half;
 $: { let svrp_start = Date.now(); let svrp_exec = Math.random(); let start_state = eval("$$self.$capture_state && $$self.$capture_state()"); rpDsp('SvelteReactiveStart', {statement: "half = count / 2;", filename: "", line: 0, id: "ABCD"}, svrp_start, svrp_exec, start_state); half = count / 2; rpDsp('SvelteReactiveEnd', {statement: "half = count / 2;", filename: "", line: 0, id: "ABCD"}, svrp_start, svrp_exec, start_state, eval("$$self.$capture_state && $$self.$capture_state()")); }
+
+ var rpGlobal = typeof window !== "undefined" ? window : global; 
+
+ rpGlobal.rpDsp = rpGlobal.rpDsp || function() {}; 
+
+rpDsp('SvelteReactiveEnable', {version: "0.8.2"});

--- a/tests/unit/output/no-semicolon.js
+++ b/tests/unit/output/no-semicolon.js
@@ -1,2 +1,7 @@
 let double;
 $: { let svrp_start = Date.now(); let svrp_exec = Math.random(); let start_state = eval("$$self.$capture_state && $$self.$capture_state()"); rpDsp('SvelteReactiveStart', {statement: "double = count * 2", filename: "", line: 0, id: "ABCD"}, svrp_start, svrp_exec, start_state); double = count * 2; rpDsp('SvelteReactiveEnd', {statement: "double = count * 2", filename: "", line: 0, id: "ABCD"}, svrp_start, svrp_exec, start_state, eval("$$self.$capture_state && $$self.$capture_state()")); }
+ var rpGlobal = typeof window !== "undefined" ? window : global; 
+
+ rpGlobal.rpDsp = rpGlobal.rpDsp || function() {}; 
+
+rpDsp('SvelteReactiveEnable', {version: "0.8.2"});

--- a/tests/unit/output/reactive.js
+++ b/tests/unit/output/reactive.js
@@ -1,2 +1,7 @@
 let double;
 $: { let svrp_start = Date.now(); let svrp_exec = Math.random(); let start_state = eval("$$self.$capture_state && $$self.$capture_state()"); rpDsp('SvelteReactiveStart', {statement: "double = count * 2;", filename: "", line: 0, id: "ABCD"}, svrp_start, svrp_exec, start_state); double = count * 2; rpDsp('SvelteReactiveEnd', {statement: "double = count * 2;", filename: "", line: 0, id: "ABCD"}, svrp_start, svrp_exec, start_state, eval("$$self.$capture_state && $$self.$capture_state()")); }
+ var rpGlobal = typeof window !== "undefined" ? window : global; 
+
+ rpGlobal.rpDsp = rpGlobal.rpDsp || function() {}; 
+
+rpDsp('SvelteReactiveEnable', {version: "0.8.2"});

--- a/tests/unit/reactive.test.js
+++ b/tests/unit/reactive.test.js
@@ -49,3 +49,12 @@ test("transform statement not terminated by semiclon", function () {
 
   expect(transformed).toContain(expected);
 });
+
+test("transform reactive statement and keep $$", function () {
+  let transformed = transform(read("input/declared-slots-variable.js"));
+  let expected = read("output/declared-slots-variable.js").trim();
+
+  console.log(diffStringsUnified(transformed, expected));
+
+  expect(expected).toContain(expected);
+});


### PR DESCRIPTION
Dollar signs are given special treatment in String.prototype.replace()
when used in the replacement string(second parameter). To avoid this
behavior, a function is used to provide the replacement string, as the
special rules applying to dollar signs does not apply to the function
return value.

This fixes a bug where the special svelte variables $$slots and $$props
would not work when this plugin is used, as $$ would be replaced with a
single $ in the compiled code.